### PR TITLE
Fix: Removed the unnecessary semicolon from categories box (Fixes #1)

### DIFF
--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -78,7 +78,7 @@ const Header = () => {
                  to={`/${category.name_encoded}`}>
                 {category.name}
                 </Link>
-              );
+              )
             })};
           </div>
         </div>


### PR DESCRIPTION
When we click on the small button comes before favourite GIFs button , it has an semicolon on the last row of different category of gifs , just removed it , cause it doesn't make any sense.


Fixes #1