### PR TITLE
FIX : Changed the github redirection link to main profile to code repo

### DIFF
--- a/src/components/follow-on.jsx
+++ b/src/components/follow-on.jsx
@@ -9,7 +9,7 @@ const FollowOn = () => {
         <a href="https://x.com/piPlaysS" className="text-gray-600 hover:text-white transition-colors duration-300">
           <FaXTwitter size={25}/>
         </a>
-        <a href="https://github.com/Suthar345Piyush" className="text-gray-600 hover:text-white transition-colors duration-300">
+        <a href="https://github.com/Suthar345Piyush/GIFHub-Gifs-App" className="text-gray-600 hover:text-white transition-colors duration-300">
           <FaGithub size={25}/>
         </a>
         <a href="https://www.linkedin.com/in/piyush-suthar-641a0826a/" className="text-gray-600 hover:text-[#0A66C2] transition-colors duration-300">


### PR DESCRIPTION
This  PR fixes the github icon redirection issue , previously it was redirecting to the main github profile , now redirecting to application codebase on github.

Changes:
1. Change the profile link to codebase link.



Fixes #3